### PR TITLE
Fix user agent string to be RFC 7231 compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ client = MarketDataClient(token="your_token_here", logger=custom_logger)
 **Client Initialization Details:**
 
 - The client automatically fetches rate limits by making a request to `/user/` endpoint during initialization
-- The client includes a User-Agent header with the format `marketdata-sdk-py-{version}` (e.g., `marketdata-sdk-py-1.1.0`)
+- The client includes a User-Agent header with the format `marketdata-sdk-py/{version}` (e.g., `marketdata-sdk-py/1.1.0`) in RFC 7231 compliant format
 - The library version is automatically detected from the installed package
 - All requests include an `Authorization: Bearer {token}` header
 - The client uses `httpx.Client` for HTTP requests with automatic connection pooling

--- a/src/marketdata/client.py
+++ b/src/marketdata/client.py
@@ -54,7 +54,7 @@ class MarketDataClient:
             self.client.close()
 
     def _get_user_agent(self) -> str:
-        return f"marketdata-sdk-py-{self.library_version}"
+        return f"marketdata-sdk-py/{self.library_version}"
 
     def _get_headers(self) -> dict[str, str]:
         headers = {

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -46,7 +46,7 @@ def test_user_rate_limits_str():
 
 
 def test_client_user_agent(client):
-    assert client._get_user_agent() == f"marketdata-sdk-py-{client.library_version}"
+    assert client._get_user_agent() == f"marketdata-sdk-py/{client.library_version}"
 
 
 def test_client_headers(client):
@@ -156,7 +156,7 @@ def test_validate_user_universal_params__function_json(monkeypatch):
 
 
 def test_client_get_user_agent(client):
-    assert client._get_user_agent() == f"marketdata-sdk-py-{client.library_version}"
+    assert client._get_user_agent() == f"marketdata-sdk-py/{client.library_version}"
 
 
 def test_client_get_headers(client):


### PR DESCRIPTION
## Changes

Changed user agent format from `marketdata-sdk-py-{version}` to `marketdata-sdk-py/{version}` to comply with RFC 7231 specification which requires `product/version` format.

## Changes Made

- Updated `_get_user_agent()` method in `client.py`
- Updated corresponding tests in `test_client.py`
- Updated README.md documentation

## Testing

All tests pass (23/23 client tests passed).

## RFC 7231 Compliance

Per RFC 7231 Section 5.5.3, the User-Agent header must follow the format:
```
product = token [ "/" product-version ]
```

The previous format used a hyphen separator which is not compliant. The new format uses a forward slash as required by the specification.