### PR TITLE
FIX: Non lib settings not allowed

### DIFF
--- a/src/marketdata/settings.py
+++ b/src/marketdata/settings.py
@@ -26,7 +26,11 @@ class MarketDataSettings(BaseSettings, UniversalParamsSettings):
     marketdata_api_version: str = "v1"
     marketdata_logging_level: str = "INFO"
 
-    model_config = ConfigDict(env_file=".env", env_file_encoding="utf-8")
+    model_config = ConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
 
 
 settings = MarketDataSettings()

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from unittest.mock import patch
 
 import pytest
@@ -15,7 +16,7 @@ from marketdata.input_types.base import OutputFormat
 from marketdata.internal_settings import NO_TOKEN_VALUE
 from marketdata.retry import get_retry_adapter
 from marketdata.sdk_error import MarketDataClientErrorResult
-from marketdata.settings import settings
+from marketdata.settings import MarketDataSettings, settings
 from marketdata.types import UserRateLimits
 from marketdata.utils import format_duration_log
 
@@ -316,3 +317,11 @@ def test_client_pre_and_post_request_logs(client, respx_mock):
             mock_logger_info.call_args_list[0].assert_called_with(
                 f"GET 200 000ms 1234567890 {last_request.request.url}"
             )
+
+
+def test_settings_extra_env_vars():
+    with patch.dict(
+        os.environ, {"RANDOM_VAR_FOR_TESTING": "123", "MARKETDATA_TOKEN": "test_token"}
+    ):
+        settings = MarketDataSettings()
+        assert settings.marketdata_token == "test_token"


### PR DESCRIPTION
## Description

This PR fixes an issue where the SDK could not be imported in applications that have unrelated environment variables defined in their `.env` file or environment. `pydantic-settings` was raising a `ValidationError` because it defaults to `extra='forbid'`, rejecting any environment variables not explicitly defined in the [MarketDataSettings](cci:2://file:///home/bctm/sdk-py/src/marketdata/settings.py:22:0-32:5) model.

## Changes

-   **[src/marketdata/settings.py](cci:7://file:///home/bctm/sdk-py/src/marketdata/settings.py:0:0-0:0)**: Updated [MarketDataSettings](cci:2://file:///home/bctm/sdk-py/src/marketdata/settings.py:22:0-32:5) configuration to include `extra="ignore"`. This allows the application to coexist with other environment variables without raising validation errors.
-   **[src/tests/test_client.py](cci:7://file:///home/bctm/sdk-py/src/tests/test_client.py:0:0-0:0)**: Added a regression test [test_settings_extra_env_vars](cci:1://file:///home/bctm/sdk-py/src/tests/test_client.py:321:0-326:56) to verify that the SDK initializes correctly even when extraneous environment variables are present.

## Impact

-   Enables the SDK to be used in multi-service applications or frameworks (like Django, Flask) that manage their own environment variables.
-   Prevents `ValidationError` at import time when the environment contains variable keys not present in the SDK's settings model.

## Verification

-   Verified locally that the SDK can now be imported in an environment with random variables.
-   Added automated test [test_settings_extra_env_vars](cci:1://file:///home/bctm/sdk-py/src/tests/test_client.py:321:0-326:56) which passes successfully.
-   Ran full test suite to ensure no regressions.