### PR TITLE
Add re-exports to package root for core types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ __marimo__/
 
 # Project specific
 output/
+
+# Mac OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ MARKETDATA_TOKEN=your_token_here
 You can pass the token when creating a client instance:
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient(token="your_token_here")
 ```
@@ -114,7 +114,7 @@ client = MarketDataClient(token="your_token_here")
 ### Create a client
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 from logging import Logger
 
 # Token will be automatically obtained from MARKETDATA_TOKEN environment variable
@@ -191,7 +191,7 @@ The SDK provides access to different market data resources:
 #### Quick Example
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 
@@ -262,8 +262,7 @@ For detailed information about return types and object structures for each resou
 You can specify the output format when calling resource methods:
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 
@@ -335,8 +334,7 @@ File path for CSV output (only used with `output_format=OutputFormat.CSV`).
 #### Example: Using Universal Parameters
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat, DateFormat, Mode
+from marketdata import MarketDataClient, OutputFormat, DateFormat, Mode
 from pathlib import Path
 
 client = MarketDataClient()
@@ -371,7 +369,7 @@ The SDK uses a combination of exceptions and return values for error handling:
 Raised when API rate limits are exceeded (before retry logic):
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 from marketdata.exceptions import RateLimitError
 
 try:
@@ -399,8 +397,7 @@ Raised for various validation errors:
 - Invalid input parameters
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 from pathlib import Path
 
 try:
@@ -420,9 +417,8 @@ except ValueError as e:
 Raised when date range validation fails (e.g., `from_date` is greater than `to_date`). This exception is typically caught internally by the `@handle_exceptions` decorator and converted to `MarketDataClientErrorResult`. You generally won't need to catch it directly unless you're working with low-level validation.
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient, MarketDataClientErrorResult
 from marketdata.exceptions import MinMaxDateValidationError
-from marketdata.sdk_error import MarketDataClientErrorResult
 import datetime
 
 try:
@@ -445,9 +441,8 @@ except MinMaxDateValidationError as e:
 Raised when arguments are passed incorrectly. Only the `symbol` or `symbols` parameter can be passed as a positional argument. All other parameters must be keyword-only:
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient, OutputFormat
 from marketdata.exceptions import KeywordOnlyArgumentError
-from marketdata.input_types.base import OutputFormat
 
 try:
     client = MarketDataClient()
@@ -467,8 +462,7 @@ except KeywordOnlyArgumentError as e:
 This is a special result type returned by resource methods when errors occur. It wraps the original exception and allows you to check for errors without exception handling. **All resource methods return either the expected result or `MarketDataClientErrorResult` - they never return `None`.**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.sdk_error import MarketDataClientErrorResult
+from marketdata import MarketDataClient, MarketDataClientErrorResult
 
 client = MarketDataClient()
 result = client.stocks.prices("AAPL")
@@ -513,9 +507,8 @@ Exceptions are caught internally by the `@handle_exceptions` decorator and conve
 Always check for `MarketDataClientErrorResult` return values and handle exceptions when calling resource methods:
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient, MarketDataClientErrorResult
 from marketdata.exceptions import RateLimitError, RequestError
-from marketdata.sdk_error import MarketDataClientErrorResult
 
 client = MarketDataClient()
 try:
@@ -551,7 +544,7 @@ All resource methods include API status checking and automatic retry logic. See 
 If a service is offline when checked, the method raises the original `RequestError` exception instead of retrying:
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 from marketdata.exceptions import RequestError
 
 client = MarketDataClient()

--- a/docs/funds.md
+++ b/docs/funds.md
@@ -5,7 +5,7 @@ The `funds` resource provides access to funds market data, including historical 
 ## Accessing the Funds Resource
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 funds = client.funds
@@ -65,7 +65,7 @@ Fetches funds candles (OHLC data) for a symbol with support for various timefram
 **Get daily candles for a fund symbol (DataFrame):**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -78,7 +78,7 @@ print(df)
 **Get candles with specific resolution:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get weekly candles
@@ -93,7 +93,7 @@ df = client.funds.candles("VFINX", resolution="Y")
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Fetch candles for a specific date range
@@ -110,7 +110,7 @@ print(df)
 **Get candles using countback:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get last 100 daily candles
@@ -121,8 +121,7 @@ print(df)
 **Get candles as internal objects:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -138,8 +137,7 @@ for candle in candles:
 **Get candles with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Date, Open, High, Low, Close instead of t, o, h, l, c
@@ -157,8 +155,7 @@ for candle in candles:
 **Get candles as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -172,8 +169,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -195,8 +191,7 @@ if csv_file:
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -237,8 +232,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument

--- a/docs/markets.md
+++ b/docs/markets.md
@@ -5,7 +5,7 @@ The `markets` resource provides access to market status information, allowing yo
 ## Accessing the Markets Resource
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 markets = client.markets
@@ -65,7 +65,7 @@ When both `from_date` and `to_date` are provided, the method validates that `fro
 **Get current market status (DataFrame):**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 df = client.markets.status()
@@ -76,7 +76,7 @@ print(df)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 df = client.markets.status(date=datetime.date(2024, 12, 25))
@@ -87,7 +87,7 @@ print(df)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 df = client.markets.status(
@@ -100,7 +100,7 @@ print(df)
 **Get market status using countback:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get market status for the last 30 days
@@ -112,7 +112,7 @@ print(df)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 df = client.markets.status(
@@ -125,8 +125,7 @@ print(df)
 **Get market status as internal objects:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 status_list = client.markets.status(
@@ -143,8 +142,7 @@ for status in status_list:
 **Get market status with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Status and Date instead of status and date
@@ -163,8 +161,7 @@ for status in status_list:
 **Get market status as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 json_data = client.markets.status(
@@ -178,8 +175,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # CSV is written to file and filename is returned
@@ -203,8 +199,7 @@ if csv_file:
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -229,8 +224,7 @@ When using `OutputFormat.INTERNAL`, the `status()` method returns a list of `Mar
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 status_list = client.markets.status(
@@ -257,8 +251,7 @@ When using `OutputFormat.INTERNAL` with `use_human_readable=True`, the `status()
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 status_list = client.markets.status(

--- a/docs/options.md
+++ b/docs/options.md
@@ -5,7 +5,7 @@ The `options` resource provides access to options market data, including expirat
 ## Accessing the Options Resource
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 options = client.options
@@ -62,7 +62,7 @@ Fetches available expiration dates for a given symbol. This method includes API 
 **Get all expirations for a symbol:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -75,8 +75,7 @@ print(df)
 **Get expirations as internal object:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -95,8 +94,7 @@ Note: `expirations()` returns a single `OptionsExpirations` object, not a list. 
 **Get expirations as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -110,8 +108,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -139,7 +136,7 @@ if csv_file:
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -240,7 +237,7 @@ Fetches the options chain for a given symbol with extensive filtering options. T
 **Get full options chain:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -254,7 +251,7 @@ print(chain)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -273,7 +270,7 @@ print(chain)
 **Filter by strike and side:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -294,7 +291,7 @@ print(chain)
 **Filter by liquidity:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -318,7 +315,7 @@ print(chain)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -345,8 +342,7 @@ print(chain)
 **Get chain as internal object:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -365,8 +361,7 @@ Note: `chain()` returns a single `OptionsChain` object, not a list. All properti
 **Get chain as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -380,8 +375,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -408,8 +402,7 @@ if csv_file:
 **Using universal parameters:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -466,7 +459,7 @@ Fetches the option symbol for a given lookup string. The lookup string should co
 **Get option symbol for specific parameters:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # lookup can be passed positionally or as keyword argument
@@ -480,8 +473,7 @@ print(lookup_result)
 **Get lookup as internal object:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # lookup can be passed positionally or as keyword argument
@@ -505,8 +497,7 @@ Note: `lookup()` returns a single `OptionsLookup` object, not a list.
 **Get lookup as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # lookup can be passed positionally or as keyword argument
@@ -526,8 +517,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # lookup can be passed positionally or as keyword argument
@@ -600,7 +590,7 @@ Fetches options quotes for one or more option symbols. This method includes API 
 **Get quotes for a single option symbol:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -613,7 +603,7 @@ print(quotes)
 **Get quotes for multiple option symbols:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -634,8 +624,7 @@ print(quotes)
 **Get quotes as internal object:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -653,8 +642,7 @@ Note: `quotes()` returns a single `OptionsQuotes` object, not a list. All proper
 **Get quotes as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -668,8 +656,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -696,8 +683,7 @@ if csv_file:
 **Using universal parameters:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -759,7 +745,7 @@ Fetches available strike prices for a given symbol. This method includes API sta
 **Get all strikes for a symbol:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -773,7 +759,7 @@ print(df)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -795,7 +781,7 @@ print(df)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -815,8 +801,7 @@ print(df)
 **Get strikes as internal object:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -839,8 +824,7 @@ Note: `strikes()` returns a single `OptionsStrikes` object, not a list. The `Opt
 **Get strikes as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -854,8 +838,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -883,8 +866,7 @@ if csv_file:
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -930,8 +912,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -984,8 +965,7 @@ All properties are lists with the same length, where each index represents a sin
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -1094,8 +1074,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -1126,8 +1105,7 @@ if quotes:
 **Get quotes with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 quotes = client.options.quotes(
@@ -1174,8 +1152,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -1215,8 +1192,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # lookup can be passed positionally or as keyword argument
@@ -1238,8 +1214,7 @@ if lookup:
 **Get lookup with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Symbol instead of optionSymbol

--- a/docs/stocks.md
+++ b/docs/stocks.md
@@ -5,7 +5,7 @@ The `stocks` resource provides access to stock market data, including real-time 
 ## Accessing the Stocks Resource
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 stocks = client.stocks
@@ -57,7 +57,7 @@ Fetches stock prices for one or more symbols. This method includes API status ch
 **Get prices for a single symbol (DataFrame):**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -80,8 +80,7 @@ print(df)
 **Get prices as internal objects:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -96,8 +95,7 @@ for price in prices:
 **Get prices as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -111,8 +109,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -132,8 +129,7 @@ if csv_file:
 **Using universal parameters:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -189,7 +185,7 @@ Fetches stock quotes for one or more symbols. This method includes API status ch
 **Get quotes for a single symbol (DataFrame):**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -212,8 +208,7 @@ print(df)
 **Get quotes as internal objects:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -231,8 +226,7 @@ for quote in quotes:
 **Get quotes with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Symbol, Ask, Bid, Mid, Last, Change_Price, Change_Percent, Volume, Date
@@ -252,8 +246,7 @@ for quote in quotes:
 **Get quotes as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -267,8 +260,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -288,8 +280,7 @@ if csv_file:
 **Using universal parameters:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -304,7 +295,7 @@ df = client.stocks.quotes(
 **Using extended quotes:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get extended quotes
@@ -315,7 +306,7 @@ print(df)
 **Using 52-week data:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get quotes with 52-week high/low
@@ -382,7 +373,7 @@ When both `from_date` and `to_date` are provided, the method behavior depends on
 **Get daily candles for a symbol (DataFrame):**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -395,7 +386,7 @@ print(df)
 **Get candles with specific resolution:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get hourly candles
@@ -410,7 +401,7 @@ df = client.stocks.candles("AAPL", resolution="W")
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Fetch candles for a specific date range
@@ -428,7 +419,7 @@ print(df)
 **Get candles using countback:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get last 100 daily candles
@@ -439,8 +430,7 @@ print(df)
 **Get candles as internal objects:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -457,8 +447,7 @@ for candle in candles:
 **Get candles with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Date, Open, High, Low, Close, Volume instead of t, o, h, l, c, v
@@ -477,8 +466,7 @@ for candle in candles:
 **Get candles as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -492,8 +480,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -515,8 +502,7 @@ if csv_file:
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -535,7 +521,7 @@ df = client.stocks.candles(
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get extended candles (pre-market and after-hours) with split adjustment
@@ -597,7 +583,7 @@ Fetches earnings data for a symbol. This method includes API status checking and
 **Get earnings for a symbol (DataFrame):**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -611,7 +597,7 @@ print(df)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Fetch earnings for a specific date range
@@ -626,7 +612,7 @@ print(df)
 **Get earnings using countback:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get last 10 earnings reports
@@ -637,8 +623,7 @@ print(df)
 **Get earnings as internal objects:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -656,8 +641,7 @@ print(f"Estimated EPS: {earnings.estimatedEPS}")
 **Get earnings with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Symbol, Fiscal_Year, Fiscal_Quarter, Reported_EPS, Estimated_EPS, etc.
@@ -677,8 +661,7 @@ print(f"Estimated EPS: {earnings.Estimated_EPS}")
 **Get earnings as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -692,8 +675,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -714,8 +696,7 @@ if csv_file:
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -775,7 +756,7 @@ Fetches news articles for a symbol. This method includes API status checking and
 **Get news for a symbol (DataFrame):**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -789,7 +770,7 @@ print(df)
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Fetch news for a specific date range
@@ -804,7 +785,7 @@ print(df)
 **Get news using countback:**
 
 ```python
-from marketdata.client import MarketDataClient
+from marketdata import MarketDataClient
 
 client = MarketDataClient()
 # Get last 50 news articles
@@ -815,8 +796,7 @@ print(df)
 **Get news as internal objects:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -835,8 +815,7 @@ for article in news:
 **Get news with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Symbol, Date instead of symbol, updated
@@ -858,8 +837,7 @@ for article in news:
 **Get news as JSON:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -873,8 +851,7 @@ print(json_data)
 
 ```python
 from pathlib import Path
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -895,8 +872,7 @@ if csv_file:
 
 ```python
 import datetime
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import DateFormat, Mode
+from marketdata import MarketDataClient, DateFormat, Mode
 
 client = MarketDataClient()
 # Use custom date format and mode
@@ -936,8 +912,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -958,8 +933,7 @@ for price in prices:
 **Get prices with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Symbol, Mid, Change_Price, Change_Percent, Date
@@ -1015,8 +989,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbols can be passed positionally or as keyword argument
@@ -1062,8 +1035,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -1120,8 +1092,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -1148,8 +1119,7 @@ for i in range(len(earnings.symbol)):
 **Get earnings with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Symbol, Fiscal_Year, Fiscal_Quarter, Reported_EPS, Estimated_EPS, etc.
@@ -1198,8 +1168,7 @@ When `use_human_readable=True`:
 ### Example Usage
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # symbol can be passed positionally or as keyword argument
@@ -1220,8 +1189,7 @@ for article in news:
 **Get news with human-readable format:**
 
 ```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 client = MarketDataClient()
 # Uses Symbol, Date instead of symbol, updated

--- a/examples/stock_candles_example.py
+++ b/examples/stock_candles_example.py
@@ -15,8 +15,7 @@ from datetime import datetime, timedelta
 
 import finplot as fplt
 
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
+from marketdata import MarketDataClient, OutputFormat
 
 VOL_SCALE = 1e6
 

--- a/examples/stock_prices_monitor_example.py
+++ b/examples/stock_prices_monitor_example.py
@@ -24,9 +24,7 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat
-from marketdata.sdk_error import MarketDataClientErrorResult
+from marketdata import MarketDataClient, MarketDataClientErrorResult, OutputFormat
 
 
 class StockPriceTracker:

--- a/src/marketdata/__init__.py
+++ b/src/marketdata/__init__.py
@@ -1,0 +1,11 @@
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import DateFormat, Mode, OutputFormat
+from marketdata.sdk_error import MarketDataClientErrorResult
+
+__all__ = [
+    "MarketDataClient",
+    "MarketDataClientErrorResult",
+    "OutputFormat",
+    "DateFormat",
+    "Mode",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "marketdata-sdk-py"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Export `MarketDataClient`, `MarketDataClientErrorResult`, `OutputFormat`, `DateFormat`, and `Mode` from the package root
- Update all documentation examples to use the cleaner import pattern

Users can now write:
```python
from marketdata import MarketDataClient, MarketDataClientErrorResult, OutputFormat, DateFormat, Mode
```

Instead of:
```python
from marketdata.client import MarketDataClient
from marketdata.sdk_error import MarketDataClientErrorResult
from marketdata.input_types.base import OutputFormat, DateFormat, Mode
```

## Test plan

- [x] All 254 tests pass with 100% coverage
- [x] Verified new imports work correctly
- [x] Verified old import paths still work (backwards compatible)

Fixes #16