### PR TITLE
FIX/`strike_limit` typed as `float` causes API requests to fail

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -198,7 +198,7 @@ Fetches the options chain for a given symbol with extensive filtering options. T
 
 - `strike` (str, optional): Filter by strike price (e.g., "150", "ATM", "ITM", "OTM")
 - `delta` (float, optional): Filter by delta value
-- `strike_limit` (float, optional): Limit the number of strikes
+- `strike_limit` (int, optional): Limit the number of strikes
 - `range` (str, optional): Strike range filter
 
 **Price / Liquidity Filters:**

--- a/src/marketdata/input_types/options.py
+++ b/src/marketdata/input_types/options.py
@@ -64,7 +64,7 @@ class OptionsChainInput(BaseInputType):
         description="The strike price to filter by", default=None
     )
     delta: float | None = Field(description="The delta to filter by", default=None)
-    strike_limit: float | None = Field(
+    strike_limit: int | None = Field(
         description="The strike limit to filter by", alias="strikeLimit", default=None
     )
     range: str | None = Field(description="The range to filter by", default=None)

--- a/src/tests/test_options_chain.py
+++ b/src/tests/test_options_chain.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytz
 
 from marketdata.input_types.base import OutputFormat
+from marketdata.input_types.options import OptionsChainInput
 from marketdata.output_types.options_chain import (
     OptionsChain,
     OptionsChainHumanReadable,
@@ -307,3 +308,29 @@ def test_options_chain_input_date_range_aliases_on_wire(load_json, respx_mock, c
     assert params.get("to") == "2026-04-18"
     assert params.get("from_date") is None
     assert params.get("to_date") is None
+
+
+def test_options_chain_input_strike_limit_typed_as_int():
+    """Issue #24: `strike_limit` is a count of strikes, so an integer input
+    must be kept as an int instead of being coerced to a float.
+    """
+    input_params = OptionsChainInput(strike_limit=10)
+    assert input_params.strike_limit == 10
+    assert type(input_params.strike_limit) is int
+
+
+def test_options_chain_strike_limit_is_int_on_wire(load_json, respx_mock, client):
+    """Issue #24: `strike_limit=10` must be sent as `strikeLimit=10`, not as the
+    float `strikeLimit=10.0` that the API rejects.
+    """
+    mock_data = load_json("options_chain_response_200")
+    respx_mock.get("https://api.marketdata.app/v1/options/chain/AAPL/").respond(
+        json=mock_data, status_code=200
+    )
+
+    client.options.chain(
+        "AAPL", strike_limit=10, output_format=OutputFormat.INTERNAL
+    )
+
+    params = respx_mock.calls.last.request.url.params
+    assert params.get("strikeLimit") == "10"


### PR DESCRIPTION
# Fix: `strike_limit` typed as `float` causes API requests to fail

Closes #24

## Summary

`options.chain(..., strike_limit=10)` failed because `strike_limit` was annotated
as `float | None`. Pydantic (lax mode) coerced the integer `10` to `10.0`, which
was then serialized into the request URL as `strikeLimit=10.0` — a value the API
rejects, since `strike_limit` is a **count of strikes**, not a price.

This PR changes the field's type to `int | None` so integer inputs stay integers
on the wire, and updates the documentation accordingly.

## Problem

```python
client.options.chain(symbol="AAPL", strike_limit=10)
# → request URL: .../options/chain/AAPL/?...&strikeLimit=10.0
# → API rejects the request
```

Root cause — `src/marketdata/input_types/options.py:67`:

```python
strike_limit: float | None = Field(
    description="The strike limit to filter by", alias="strikeLimit", default=None
)
```

## Changes

### `src/marketdata/input_types/options.py`
```diff
-    strike_limit: float | None = Field(
+    strike_limit: int | None = Field(
         description="The strike limit to filter by", alias="strikeLimit", default=None
     )
```

With `int | None`, Pydantic keeps `10` as `10`, and `_build_url` serializes it
into `strikeLimit=10`.

### `docs/options.md`
```diff
-- `strike_limit` (float, optional): Limit the number of strikes
+- `strike_limit` (int, optional): Limit the number of strikes
```

## Testing

Two new tests in `src/tests/test_options_chain.py`, covering the bug at two
levels:

- **`test_options_chain_input_strike_limit_typed_as_int`** — unit test on the
  input model. Asserts that `OptionsChainInput(strike_limit=10).strike_limit` is
  kept as an `int` (`type(...) is int`), not coerced to a `float`.
- **`test_options_chain_strike_limit_is_int_on_wire`** — integration test that
  inspects the actual outgoing request via
  `respx_mock.calls.last.request.url.params` and asserts
  `params["strikeLimit"] == "10"` (not `"10.0"`). Mirrors the existing
  `test_options_chain_input_date_range_aliases_on_wire` pattern.

Developed with a TDD red → green cycle.

```
297 passed
```

Full suite green — no regressions.

## Files changed

| File | Change |
|------|--------|
| `src/marketdata/input_types/options.py` | `strike_limit` retyped `float \| None` → `int \| None` |
| `docs/options.md` | Documented type updated to `int` |
| `src/tests/test_options_chain.py` | 2 new regression tests |
