### PR TITLE
Fix/quiet the SDK's default logging output

### DIFF
--- a/src/marketdata/client.py
+++ b/src/marketdata/client.py
@@ -43,8 +43,8 @@ class MarketDataClient:
             self.token if self.token == NO_TOKEN_VALUE else obfuscate_token(self.token)
         )
         self.logger.debug(f"Token: {logged_token}")
-        self.logger.info(f"Base URL: {settings.marketdata_base_url}")
-        self.logger.info(f"API Version: {settings.marketdata_api_version}")
+        self.logger.debug(f"Base URL: {settings.marketdata_base_url}")
+        self.logger.debug(f"API Version: {settings.marketdata_api_version}")
 
         self.base_url = settings.marketdata_base_url
         self.api_version = settings.marketdata_api_version

--- a/src/marketdata/settings.py
+++ b/src/marketdata/settings.py
@@ -24,7 +24,7 @@ class MarketDataSettings(BaseSettings, UniversalParamsSettings):
     marketdata_token: str | NoTokenValueType = NO_TOKEN_VALUE
     marketdata_base_url: str = "https://api.marketdata.app"
     marketdata_api_version: str = "v1"
-    marketdata_logging_level: str = "INFO"
+    marketdata_logging_level: str = "WARNING"
 
     model_config = ConfigDict(
         env_file=".env",

--- a/src/tests/test_client.py
+++ b/src/tests/test_client.py
@@ -1,6 +1,7 @@
 import datetime
 import os
-from unittest.mock import patch
+from logging import Logger
+from unittest.mock import MagicMock, patch
 
 import pytest
 import pytz
@@ -412,3 +413,45 @@ def test_settings_extra_env_vars():
     ):
         settings = MarketDataSettings()
         assert settings.marketdata_token == "test_token"
+
+
+def test_default_logging_level_is_warning(monkeypatch):
+    """Issue #25: the SDK must default to WARNING so importing it does not
+    flood the user's terminal with INFO output.
+    """
+    monkeypatch.delenv("MARKETDATA_LOGGING_LEVEL", raising=False)
+    fresh_settings = MarketDataSettings()
+    assert fresh_settings.marketdata_logging_level == "WARNING"
+
+
+def test_client_init_base_url_and_api_version_logged_at_debug(respx_mock):
+    """Issue #25: `Base URL` and `API Version` must be logged at DEBUG rather
+    than INFO so that the default INFO output stays quiet.
+    """
+    headers = {
+        "x-api-ratelimit-limit": "100",
+        "x-api-ratelimit-remaining": "99",
+        "x-api-ratelimit-reset": "60",
+        "x-api-ratelimit-consumed": "1",
+    }
+    respx_mock.get("https://api.marketdata.app/user/").respond(
+        json={}, headers=headers, status_code=200
+    )
+
+    logger = MagicMock(spec=Logger)
+    MarketDataClient(token="test", logger=logger)
+
+    info_messages = [call.args[0] for call in logger.info.call_args_list]
+    debug_messages = [call.args[0] for call in logger.debug.call_args_list]
+
+    # Sanity: the constructor still emits the top-level "Initializing" line at
+    # INFO, so the mock is wired correctly.
+    assert any("Initializing" in m for m in info_messages)
+
+    # The noisy details must not be at INFO anymore.
+    assert not any("Base URL" in m for m in info_messages)
+    assert not any("API Version" in m for m in info_messages)
+
+    # They must still be available, just at DEBUG.
+    assert any("Base URL" in m for m in debug_messages)
+    assert any("API Version" in m for m in debug_messages)


### PR DESCRIPTION
# Fix: quiet the SDK's default logging output

Closes #25

## Summary

Importing the SDK and constructing a `MarketDataClient` produced several INFO
log lines — and one more on every HTTP request — flooding the user's terminal
with output most callers do not care about. Worse, the only way to silence it
was to discover the undocumented `MARKETDATA_LOGGING_LEVEL` environment
variable.

This PR raises the SDK's default logging threshold to `WARNING` and downgrades
the chatty initialization messages to `DEBUG`. Users who want the previous
verbose behavior can still opt in via `MARKETDATA_LOGGING_LEVEL=INFO`.

## Problem

```python
from marketdata import MarketDataClient
c = MarketDataClient(token="...")
# 2026-05-28 ... INFO - Initializing MarketDataClient
# 2026-05-28 ... INFO - Base URL: https://api.marketdata.app
# 2026-05-28 ... INFO - API Version: v1
# 2026-05-28 ... INFO - GET 200 ... /user/
```

Three INFO entries just to instantiate the client, plus one per HTTP request.

## Changes

### `src/marketdata/settings.py`
```diff
-    marketdata_logging_level: str = "INFO"
+    marketdata_logging_level: str = "WARNING"
```

The default is now quiet. Library output stays out of the user's way unless
they opt in.

### `src/marketdata/client.py`
```diff
         self.logger.debug(f"Token: {logged_token}")
-        self.logger.info(f"Base URL: {settings.marketdata_base_url}")
-        self.logger.info(f"API Version: {settings.marketdata_api_version}")
+        self.logger.debug(f"Base URL: {settings.marketdata_base_url}")
+        self.logger.debug(f"API Version: {settings.marketdata_api_version}")
```

`Base URL` and `API Version` are implementation details, not user-facing
events. They are now at `DEBUG`, aligned with the existing `Token` log right
above them. They remain available for troubleshooting via
`MARKETDATA_LOGGING_LEVEL=DEBUG`.

## What was intentionally left alone

- **`Initializing MarketDataClient`** stays at `INFO`. The issue does not ask
  for it to move; a regression test pins this. With the new `WARNING` default,
  it is silent for normal users anyway.
- **Per-request log in `_post_request_logs`** (`response_log_level=INFO`) is
  unchanged. Not part of the proposed solution, and the new default silences
  it for casual use while still surfacing it when users explicitly raise the
  level.

## Testing

Two new tests in `src/tests/test_client.py`, one per change:

- **`test_default_logging_level_is_warning`** — instantiates a fresh
  `MarketDataSettings()` with `MARKETDATA_LOGGING_LEVEL` removed from the
  environment and asserts the default is `"WARNING"`. Uses `monkeypatch.delenv`
  to neutralize any shell-leaked env var.
- **`test_client_init_base_url_and_api_version_logged_at_debug`** — injects a
  `MagicMock(spec=Logger)` into the constructor and asserts:
  - `Base URL` / `API Version` are **not** in `logger.info` calls,
  - they **are** in `logger.debug` calls,
  - `Initializing` stays in `logger.info` (sanity check that locks behavior).

Mocking the logger directly lets the tests verify *which method* was called
without depending on log-level filtering, root-logger propagation, or
`caplog` setup.

Developed with a TDD red → green cycle.

```
297 passed
```

Full suite green — no regressions.

## Files changed

| File | Change |
|------|--------|
| `src/marketdata/settings.py` | Default `marketdata_logging_level`: `INFO` → `WARNING` |
| `src/marketdata/client.py` | `Base URL` / `API Version` init logs: `info` → `debug` |
| `src/tests/test_client.py` | 2 new regression tests |
