### PR TITLE
Fix: `days_to_expiration` sent under wrong query param name (`dte`)

### DIFF
--- a/src/marketdata/input_types/options.py
+++ b/src/marketdata/input_types/options.py
@@ -35,7 +35,9 @@ class OptionsChainInput(BaseInputType):
         description="The expiration date to filter by", default=None
     )
     days_to_expiration: int | None = Field(
-        description="The number of days to expiration to filter by", default=None
+        description="The number of days to expiration to filter by",
+        alias="dte",
+        default=None,
     )
     from_date: datetime.date | str | None = Field(
         description="The start date to fetch options chain for",

--- a/src/tests/test_input_types.py
+++ b/src/tests/test_input_types.py
@@ -1,15 +1,19 @@
 import datetime
+import importlib
+import pkgutil
 from pathlib import Path
 
 import pytest
 from pydantic import Field, model_validator
 
+import marketdata.input_types as input_types_pkg
 from marketdata.exceptions import MinMaxDateValidationError
 from marketdata.input_types.base import (
     BaseInputType,
     OutputFormat,
     UserUniversalAPIParams,
 )
+from marketdata.internal_settings import GLOBAL_EXCLUDED_PARAMS
 
 
 class DummyInput(BaseInputType):
@@ -20,6 +24,70 @@ class DummyInput(BaseInputType):
     def validate_input(self) -> "DummyInput":
         self._validate_min_max_dates("min_param", "max_param")
         return self
+
+
+def _all_input_models() -> list[type[BaseInputType]]:
+    """Return every concrete BaseInputType subclass defined in the SDK.
+
+    Imports each input_types submodule first so all subclasses are registered.
+    """
+    for module_info in pkgutil.iter_modules(input_types_pkg.__path__):
+        importlib.import_module(f"{input_types_pkg.__name__}.{module_info.name}")
+
+    seen: set[type[BaseInputType]] = set()
+    stack: list[type[BaseInputType]] = [BaseInputType]
+    while stack:
+        for sub in stack.pop().__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                stack.append(sub)
+    # Only audit models shipped in the SDK, not test-only helper subclasses.
+    return sorted(
+        (c for c in seen if c.__module__.startswith(input_types_pkg.__name__)),
+        key=lambda c: c.__name__,
+    )
+
+
+def _snake_case_fields() -> list[tuple[str, str, "object"]]:
+    """All (model_name, field_name, field) tuples for fields whose Python name
+    differs from a bare API parameter (i.e. contain an underscore)."""
+    cases = []
+    for model in _all_input_models():
+        for field_name, field in model.model_fields.items():
+            if "_" in field_name:
+                cases.append((model.__name__, field_name, field))
+    return cases
+
+
+_SNAKE_CASE_FIELDS = _snake_case_fields()
+
+
+def test_snake_case_field_discovery_is_not_empty():
+    # Guard: if discovery silently breaks, the parametrized test below would
+    # vacuously pass. days_to_expiration alone guarantees at least one case.
+    assert _SNAKE_CASE_FIELDS
+
+
+@pytest.mark.parametrize(
+    "model_name, field_name, field",
+    _SNAKE_CASE_FIELDS,
+    ids=[f"{m}.{f}" for m, f, _ in _SNAKE_CASE_FIELDS],
+)
+def test_snake_case_input_fields_have_api_alias(model_name, field_name, field):
+    """Every multi-word input field must be sent under an explicit API alias.
+
+    The URL builder serializes with ``by_alias=True``; a snake_case field
+    without an alias would leak its Python name to the wire (see issue #30,
+    ``days_to_expiration`` -> ``dte``). Fields that are never serialized to the
+    query string are exempted via GLOBAL_EXCLUDED_PARAMS.
+    """
+    if field_name in GLOBAL_EXCLUDED_PARAMS:
+        return
+
+    assert field.alias and field.alias != field_name, (
+        f"{model_name}.{field_name} has no API alias; it would be sent to the "
+        f"API as '{field_name}'. Add an alias or exclude it."
+    )
 
 
 def test_base_input_type_min_max_validation():

--- a/src/tests/test_options_chain.py
+++ b/src/tests/test_options_chain.py
@@ -307,3 +307,22 @@ def test_options_chain_input_date_range_aliases_on_wire(load_json, respx_mock, c
     assert params.get("to") == "2026-04-18"
     assert params.get("from_date") is None
     assert params.get("to_date") is None
+
+
+def test_options_chain_input_days_to_expiration_alias_on_wire(
+    load_json, respx_mock, client
+):
+    mock_data = load_json("options_chain_response_200")
+    respx_mock.get("https://api.marketdata.app/v1/options/chain/AAPL/").respond(
+        json=mock_data, status_code=200
+    )
+
+    client.options.chain(
+        "AAPL",
+        days_to_expiration=30,
+        output_format=OutputFormat.INTERNAL,
+    )
+
+    params = respx_mock.calls.last.request.url.params
+    assert params.get("dte") == "30"
+    assert params.get("days_to_expiration") is None


### PR DESCRIPTION
# Fix: `days_to_expiration` sent under wrong query param name (`dte`)

Closes #30

## Summary

The `days_to_expiration` filter on `client.options.chain(...)` was silently
ignored by the API. The URL builder serializes input models with
`by_alias=True` (`src/marketdata/resources/base.py:45`), but the
`days_to_expiration` field had no Pydantic `alias`, so it was emitted to the
wire under its Python name (`days_to_expiration=30`) instead of the parameter
the API expects (`dte=30`). The backend doesn't recognize that key, so the
filter was dropped without error and the full chain was returned.

```python
client.options.chain(symbol="AAPL", days_to_expiration=30)
# before: ...?days_to_expiration=30   -> ignored by API
# after:  ...?dte=30                  -> filter applied
```

## Changes

### 1. The fix — `src/marketdata/input_types/options.py`
Added `alias="dte"` to the `days_to_expiration` field, matching the existing
convention used by every other renamed field in the model (`strikeLimit`,
`minBid`, `from`/`to`, etc.). Because `BaseModelConfig` sets
`populate_by_name=True`, callers keep using `days_to_expiration=...` while the
emitted query parameter is now `dte`.

### 2. Targeted regression test — `src/tests/test_options_chain.py`
`test_options_chain_input_days_to_expiration_alias_on_wire` asserts that a real
request carries `dte=30` on the wire and never `days_to_expiration`, mirroring
the existing `from_date`/`to_date` alias test.

### 3. Preventive test for the whole bug class — `src/tests/test_input_types.py`
A parametrized test (`test_snake_case_input_fields_have_api_alias`)
auto-discovers every `BaseInputType` model in the SDK and asserts that any field
whose Python name contains an underscore is sent under an explicit `alias`
(or is exempt via `GLOBAL_EXCLUDED_PARAMS`, like `output_format`/`filename`,
which never reach the query string). A guard test ensures discovery isn't
silently empty. This catches the *next* field that forgets its alias, not just
this one.

## Audit

I audited every input model across `options.py`, `funds.py`, `markets.py`,
`stocks.py`, and `base.py`. `days_to_expiration` was the **only** field missing
an alias — all other renamed fields (`strike_limit`, `min_bid`/`max_bid`,
`min_ask`/`max_ask`, `max_bid_ask_spread[_pct]`, `min_open_interest`,
`min_volume`, `from_date`/`to_date`, `use_52_week`, `adjust_splits`,
`report_type`, `date_format`, `add_headers`, `use_human_readable`) already
carry the correct alias. The new preventive test now enforces this invariant.

## Testing

- Verified the new alias test **fails** when the `alias="dte"` fix is reverted,
  confirming it isn't a false green.
- Full suite: **328 passed**.