### PR TITLE
Fix: min/max price filters on OptionsChainInput are never validated (#32)

### DIFF
--- a/src/marketdata/exceptions.py
+++ b/src/marketdata/exceptions.py
@@ -94,5 +94,13 @@ class InvalidStatusDataError(BaseMarketdataException):
     pass
 
 
-class MinMaxDateValidationError(BaseMarketdataException):
+class MinMaxValidationError(BaseMarketdataException):
+    pass
+
+
+class MinMaxValueValidationError(MinMaxValidationError):
+    pass
+
+
+class MinMaxDateValidationError(MinMaxValidationError):
     pass

--- a/src/marketdata/input_types/base.py
+++ b/src/marketdata/input_types/base.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from marketdata.exceptions import MinMaxDateValidationError
+from marketdata.exceptions import MinMaxDateValidationError, MinMaxValueValidationError
 from marketdata.utils import check_is_date
 
 BaseModelConfig = ConfigDict(populate_by_name=True, frozen=False)
@@ -25,6 +25,17 @@ class BaseInputType(BaseModel):
                 raise MinMaxDateValidationError(
                     f"{min_param} must be less than {max_param}"
                 )
+
+    def _validate_min_max_value(
+        self, min_param: str | None, max_param: str | None
+    ) -> None:
+        min_value = getattr(self, min_param)
+        max_value = getattr(self, max_param)
+
+        if min_value is not None and max_value is not None and min_value > max_value:
+            raise MinMaxValueValidationError(
+                f"{min_param} must be less than or equal to {max_param}"
+            )
 
 
 class OutputFormat(str, Enum):

--- a/src/marketdata/input_types/options.py
+++ b/src/marketdata/input_types/options.py
@@ -123,12 +123,12 @@ class OptionsChainInput(BaseInputType):
 
     @model_validator(mode="after")
     def validate_input(self) -> "OptionsChainInput":
-        params_typles = [
+        params_tuples = [
             ("min_bid", "max_bid"),
             ("min_ask", "max_ask"),
         ]
-        for min_param, max_param in params_typles:
-            self._validate_min_max_dates(min_param, max_param)
+        for min_param, max_param in params_tuples:
+            self._validate_min_max_value(min_param, max_param)
         return self
 
 

--- a/src/tests/test_input_types.py
+++ b/src/tests/test_input_types.py
@@ -4,12 +4,17 @@ from pathlib import Path
 import pytest
 from pydantic import Field, model_validator
 
-from marketdata.exceptions import MinMaxDateValidationError
+from marketdata.exceptions import (
+    MinMaxDateValidationError,
+    MinMaxValidationError,
+    MinMaxValueValidationError,
+)
 from marketdata.input_types.base import (
     BaseInputType,
     OutputFormat,
     UserUniversalAPIParams,
 )
+from marketdata.input_types.options import OptionsChainInput
 
 
 class DummyInput(BaseInputType):
@@ -22,9 +27,65 @@ class DummyInput(BaseInputType):
         return self
 
 
+class DummyNumericInput(BaseInputType):
+    min_param: float | None = Field(default=None)
+    max_param: float | None = Field(default=None)
+
+    @model_validator(mode="after")
+    def validate_input(self) -> "DummyNumericInput":
+        self._validate_min_max_value("min_param", "max_param")
+        return self
+
+
 def test_base_input_type_min_max_validation():
     with pytest.raises(MinMaxDateValidationError):
         DummyInput(min_param="2025-01-01", max_param="2024-01-01")
+
+
+def test_base_input_type_min_max_value_validation():
+    with pytest.raises(MinMaxValueValidationError):
+        DummyNumericInput(min_param=5.0, max_param=1.0)
+
+
+def test_base_input_type_min_max_value_valid_range():
+    instance = DummyNumericInput(min_param=1.0, max_param=5.0)
+    assert instance.min_param == 1.0
+    assert instance.max_param == 5.0
+
+
+def test_base_input_type_min_max_value_allows_none():
+    # Either bound missing -> no comparison, no error.
+    assert DummyNumericInput(min_param=5.0).max_param is None
+    assert DummyNumericInput(max_param=1.0).min_param is None
+    assert DummyNumericInput().min_param is None
+
+
+def test_min_max_errors_share_common_base():
+    # Both specialized errors must be catchable as the common MinMaxValidationError.
+    assert issubclass(MinMaxDateValidationError, MinMaxValidationError)
+    assert issubclass(MinMaxValueValidationError, MinMaxValidationError)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"min_bid": 5.0, "max_bid": 1.0},
+        {"min_ask": 10.0, "max_ask": 2.0},
+    ],
+)
+def test_options_chain_input_invalid_price_range(kwargs: dict):
+    with pytest.raises(MinMaxValueValidationError):
+        OptionsChainInput(symbol="AAPL", **kwargs)
+
+
+def test_options_chain_input_valid_price_range():
+    instance = OptionsChainInput(
+        symbol="AAPL", min_bid=1.0, max_bid=5.0, min_ask=2.0, max_ask=10.0
+    )
+    assert instance.min_bid == 1.0
+    assert instance.max_bid == 5.0
+    assert instance.min_ask == 2.0
+    assert instance.max_ask == 10.0
 
 
 def test_universal_api_params_api_format():


### PR DESCRIPTION
# Fix: min/max price filters on `OptionsChainInput` are never validated

Closes #32

## Problem

`OptionsChainInput` declared a `model_validator` meant to enforce `min ≤ max` on
the bid/ask **price** filters, but the check never ran. It reused the date-only
helper `_validate_min_max_dates`, which compares the two values only when *both*
pass `check_is_date(...)`. Bid/ask filters are `float`, so the comparison was
skipped entirely and an inverted range was accepted silently:

```python
# Before: constructs fine, no error raised.
OptionsChainInput(symbol="AAPL", min_bid=5.0, max_bid=1.0)
OptionsChainInput(symbol="AAPL", min_ask=10.0, max_ask=2.0)
```

This sent obviously invalid requests to the API instead of rejecting them
client-side, defeating the purpose of the validator. There was also a typo in
the local variable (`params_typles`).

## Changes

- **`exceptions.py`** — introduced a common base `MinMaxValidationError`, with
  two specialized subclasses sharing it:
  - `MinMaxValueValidationError` — numeric ranges.
  - `MinMaxDateValidationError` — date ranges (previously a direct subclass of
    `BaseMarketdataException`; now also catchable as `MinMaxValidationError`).
- **`input_types/base.py`** — added a numeric-aware helper
  `_validate_min_max_value(min_param, max_param)` that raises
  `MinMaxValueValidationError` when both bounds are set and `min > max`. The
  existing `_validate_min_max_dates` is kept for genuine date ranges.
- **`input_types/options.py`** — `OptionsChainInput.validate_input` now uses
  `_validate_min_max_value` for the `(min_bid, max_bid)` and `(min_ask, max_ask)`
  pairs, and fixed the `params_typles` → `params_tuples` typo.

## Why a separate helper instead of reusing the date helper

Date filters can be `datetime.date` or strings in several formats, so they need
the `check_is_date` gating. Price filters are plain numbers and just need a
direct `min > max` comparison. Keeping the two helpers separate avoids
overloading one path and keeps each validation intent explicit.

## Scope note

`min_open_interest`, `min_volume`, `max_bid_ask_spread`, and
`max_bid_ask_spread_pct` have no `min/max` counterpart in the model, so there are
no other ordered numeric pairs to validate.
